### PR TITLE
Shorten game titles to fit in all games menu

### DIFF
--- a/_games/agu.md
+++ b/_games/agu.md
@@ -1,5 +1,5 @@
 ---
-title: "All Grown Up: Confiscated Cards"
+title: "All Grown Up"
 description: "Help the Rugrats collect Chuckie's confiscated Yu-Gotta-Go cards!"
 developer: "Denki"
 brand: "Nickelodeon"

--- a/_games/beehive.md
+++ b/_games/beehive.md
@@ -1,5 +1,5 @@
 ---
-title: "Beehive Bedlam (Denki)"
+title: "Beehive Bedlam 2"
 description: "Never released!"
 developer: "Denki"
 brand: "SKY Games"

--- a/_games/ben10.md
+++ b/_games/ben10.md
@@ -1,5 +1,5 @@
 ---
-title: "Ben 10: Vilgax Venom"
+title: "Ben 10 1"
 description: "Fight off robots in an alien assault!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/ben10_2.md
+++ b/_games/ben10_2.md
@@ -1,5 +1,5 @@
 ---
-title: "Ben 10: Call of the Wildmutt"
+title: "Ben 10 2"
 description: ""
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/ben10_3.md
+++ b/_games/ben10_3.md
@@ -1,5 +1,5 @@
 ---
-title: "Ben 10: Upchuck Unveiled"
+title: "Ben 10 3"
 description: ""
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/ben10_4.md
+++ b/_games/ben10_4.md
@@ -1,5 +1,5 @@
 ---
-title: "Ben 10: Howlin' Benwolf"
+title: "Ben 10 4"
 description: ""
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/cknd.md
+++ b/_games/cknd.md
@@ -1,5 +1,5 @@
 ---
-title: "Codename Kids Next Door"
+title: "KND: BITTERSWEET"
 description: "Stop the evil Stickybeard in his tracks!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/cknd2.md
+++ b/_games/cknd2.md
@@ -1,5 +1,5 @@
 ---
-title: "Codename Kids Next Door 2.0"
+title: "KND 2.0"
 description: "Kids versus grown-ups, the ultimate battle of wits!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/cknd_2.md
+++ b/_games/cknd_2.md
@@ -1,5 +1,5 @@
 ---
-title: "Codename Kids Next Door Episode 2"
+title: "KND: SHIPWRECKED"
 description: "Numbuh Four takes to the pirates head-on!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/cknd_3.md
+++ b/_games/cknd_3.md
@@ -1,5 +1,5 @@
 ---
-title: "Codename Kids Next Door Episode 3"
+title: "KND: REVENGE"
 description: "Sink the Sweet Revenge III once and for all!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/courage.md
+++ b/_games/courage.md
@@ -1,5 +1,5 @@
 ---
-title: "Courage the Cowardly Dog 1"
+title: "Courage 1"
 description: "Save Eustace and Muriel from the evil Katz!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/courage2.md
+++ b/_games/courage2.md
@@ -1,5 +1,5 @@
 ---
-title: "Courage the Cowardly Dog 2"
+title: "Courage 2"
 description: "Katz is back, and wanting more!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/courage3.md
+++ b/_games/courage3.md
@@ -1,5 +1,5 @@
 ---
-title: "Courage the Cowardly Dog 3"
+title: "Courage 3"
 description: "Eustace and Muriel have been kidnapped again - but not by who you think!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/dl.md
+++ b/_games/dl.md
@@ -1,5 +1,5 @@
 ---
-title: "Dexter vs. Mandark"
+title: "Dexter's Lab"
 description: "A battle of wits between two evil geniuses!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/dl2.md
+++ b/_games/dl2.md
@@ -1,5 +1,5 @@
 ---
-title: "Dexter: Mandark Strikes Back"
+title: "Dexter's Lab 2"
 description: "Dexter's feud with Mandark continues!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/dl3.md
+++ b/_games/dl3.md
@@ -1,5 +1,5 @@
 ---
-title: "Dexter: Dorkster's Revenge"
+title: "Dexter's Lab 3"
 description: "Take the battle to Mandark's laboratory!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/dynamice.md
+++ b/_games/dynamice.md
@@ -1,5 +1,5 @@
 ---
-title: "Tom and Jerry: Dynamice"
+title: "T&J Dynamice"
 description: "Bombs away!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/dynamice2.md
+++ b/_games/dynamice2.md
@@ -1,5 +1,5 @@
 ---
-title: "Tom and Jerry: Dynamice 2"
+title: "T&J Dynamice 2"
 description: "Bombs away!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/fosters.md
+++ b/_games/fosters.md
@@ -1,5 +1,5 @@
 ---
-title: "Foster's Home for Imaginary Friends"
+title: "Foster's 1"
 description: "Reset clocks to fix the timeline"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/jf_cn.md
+++ b/_games/jf_cn.md
@@ -1,5 +1,5 @@
 ---
-title: "Jumble Fever: Cartoon Network"
+title: "Jumble Fever: CN"
 description: "Fruity addicting fun!"
 developer: "Denki"
 brand: "SKY Games"

--- a/_games/jf_sd.md
+++ b/_games/jf_sd.md
@@ -1,5 +1,5 @@
 ---
-title: "Jumble Fever: Scooby-Doo"
+title: "Jumble Fever: Scooby"
 description: "Fruity addicting fun!"
 developer: "Denki"
 brand: "SKY Games"

--- a/_games/jf_tj.md
+++ b/_games/jf_tj.md
@@ -1,5 +1,5 @@
 ---
-title: "Jumble Fever: Tom and Jerry"
+title: "Jumble Fever: T&J"
 description: "Fruity addicting fun!"
 developer: "Denki"
 brand: "SKY Games"

--- a/_games/lego.md
+++ b/_games/lego.md
@@ -1,5 +1,5 @@
 ---
-title: "Lego Castle: The Sword of Virtue"
+title: "Lego Castle"
 description: "Save the West from siege!"
 developer: "Denki"
 brand: "LEGO"

--- a/_games/lt.md
+++ b/_games/lt.md
@@ -1,5 +1,5 @@
 ---
-title: "Looney Tunes: Back in Action"
+title: "Looney Tunes"
 description: "Bugs and Daffy need your help!"
 developer: "Denki"
 brand: "Warner Bros"

--- a/_games/lt2.md
+++ b/_games/lt2.md
@@ -1,5 +1,5 @@
 ---
-title: "Looney Tunes: Back in Action 2"
+title: "Looney Tunes 2"
 description: "ACME strikes back!"
 developer: "Denki"
 brand: "Warner Bros"

--- a/_games/lt3.md
+++ b/_games/lt3.md
@@ -1,5 +1,5 @@
 ---
-title: "Looney Tunes: Back in Action 3"
+title: "Looney Tunes 3"
 description: "Oh no! Bugs has been kidnapped by ACME!"
 developer: "Denki"
 brand: "Warner Bros"

--- a/_games/robotboy1.md
+++ b/_games/robotboy1.md
@@ -1,5 +1,5 @@
 ---
-title: "Robotboy Episode 1"
+title: "Robotboy 1"
 description: "Kamikazi has kidnapped Robotboy's friends!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/robotboy2.md
+++ b/_games/robotboy2.md
@@ -1,5 +1,5 @@
 ---
-title: "Robotboy Episode 2"
+title: "Robotboy 2"
 description: "A gargantuan creation awaits Robotboy!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/robotboy3.md
+++ b/_games/robotboy3.md
@@ -1,5 +1,5 @@
 ---
-title: "Robotboy Episode 3"
+title: "Robotboy 3"
 description: "Help repair Robotboy's Superactivator!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/robotboy4.md
+++ b/_games/robotboy4.md
@@ -1,5 +1,5 @@
 ---
-title: "Robotboy Episode 4"
+title: "Robotboy 4"
 description: "Double trouble for Robotboy and friends!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/sb.md
+++ b/_games/sb.md
@@ -1,5 +1,5 @@
 ---
-title: "SpongeBob SquarePants 1"
+title: "SpongeBob 1"
 description: "Evade the Thug Tugs and bring justice to longtime rival Plankton!"
 developer: "Denki"
 brand: "Nickelodeon"

--- a/_games/sb2.md
+++ b/_games/sb2.md
@@ -1,5 +1,5 @@
 ---
-title: "SpongeBob SquarePants 2"
+title: "SpongeBob 2"
 description: "Help Krabs recover the secret formula!"
 developer: "Denki"
 brand: "Nickelodeon"

--- a/_games/sb3.md
+++ b/_games/sb3.md
@@ -1,5 +1,5 @@
 ---
-title: "SpongeBob SquarePants 3"
+title: "SpongeBob 3"
 description: "Where's Gary? He's been kidnapped by the ghostly Flying Dutchman!"
 developer: "Denki"
 brand: "Nickelodeon"

--- a/_games/sb4.md
+++ b/_games/sb4.md
@@ -1,5 +1,5 @@
 ---
-title: "SpongeBob SquarePants 4"
+title: "SpongeBob 4"
 description: "Plankton has duped Neptune!"
 developer: "Denki"
 brand: "Nickelodeon"

--- a/_games/sd.md
+++ b/_games/sd.md
@@ -1,5 +1,5 @@
 ---
-title: "Scooby-Doo: Eerie Isle"
+title: "Scooby: Eerie Isle"
 description: "Help the Mystery gang track down the ghosts of Eerie Isle!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/sd2.md
+++ b/_games/sd2.md
@@ -1,5 +1,5 @@
 ---
-title: "Scooby-Doo: Mummy Madness"
+title: "Scooby: Mummy Madness"
 description: "Help Mystery Inc tackle a haunted museum!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/sd3.md
+++ b/_games/sd3.md
@@ -1,5 +1,5 @@
 ---
-title: "Scooby-Doo: Mystery Mine"
+title: "Scooby: Mystery Mine"
 description: "Scooby's gang is tasked with navigating the Mysterious Manor!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/sd4.md
+++ b/_games/sd4.md
@@ -1,5 +1,5 @@
 ---
-title: "Scooby-Doo: Tomb It May Concern"
+title: "Scooby: Ankhamon"
 description: "Solve the curse of Ankhanamon!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/stb.md
+++ b/_games/stb.md
@@ -1,5 +1,5 @@
 ---
-title: "Denki's Sticky Blocks!"
+title: "Sticky Blocks"
 description: "Denki Blocks is back and stickier than ever!"
 developer: "Denki"
 brand: "Denki"

--- a/_games/tbirds.md
+++ b/_games/tbirds.md
@@ -1,5 +1,5 @@
 ---
-title: "Thunderbirds: Flashpoint Earth"
+title: "Thunderbirds"
 description: "International Rescue is under high demand!"
 developer: "Denki"
 brand: "Universal Studios"

--- a/_games/tj.md
+++ b/_games/tj.md
@@ -1,5 +1,5 @@
 ---
-title: "Tom and Jerry: Mouse Party"
+title: "T&J Episode 1"
 description: "Rescue orphan mice while avoiding cats!"
 developer: "Denki"
 brand: "Cartoon Network"

--- a/_games/tj3.md
+++ b/_games/tj3.md
@@ -1,5 +1,5 @@
 ---
-title: "Tom and Jerry Episode 3"
+title: "T&J Episode 3"
 developer: "Denki"
 brand: "Cartoon Network"
 menu: "Cartoon Network/Tom and Jerry/Tom and Jerry Episode 3/ModeSelect.jpg"

--- a/_games/tj_ff.md
+++ b/_games/tj_ff.md
@@ -1,5 +1,5 @@
 ---
-title: "Tom and jerry food fight"
+title: "T&J Food Fight"
 menu: Cartoon Network/Tom and Jerry/Tom and Jerry Food Fight/menu.png
 modes:
  - Easy


### PR DESCRIPTION
Shorten the game titles so that they display correctly on the Sky Games Go client